### PR TITLE
refactor: raise node floor to 22, adopt Array.fromAsync, repair blockstore types

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,11 +16,11 @@
         "@stauro/filebase-upload": "npm:@jsr/stauro__filebase-upload",
         "@types/bun": "^1.3.10",
         "@types/varint": "^6.0.3",
+        "abort-error": "^1.0.2",
         "hamt-sharding": "^3.0.8",
         "interface-blockstore": "^7.0.1",
         "interface-store": "^8.0.0",
         "ipfs-unixfs": "^13.0.0",
-        "it-all": "^3.0.11",
         "multiformats": "^14.0.0",
         "nanotar": "^0.3.0",
         "ox": "^0.14.8",
@@ -253,8 +253,6 @@
     "is-unicode-supported": ["is-unicode-supported@2.1.0", "", {}, "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
-
-    "it-all": ["it-all@3.0.11", "", {}, "sha512-Gvqj6MO4GMLnFdtE68HZRpGBskNC+9+GQ+JevTGNYLyhjUuPhjDLU3jN1LpBemXJDW1bRSkczqA/qGyKlPKrcQ=="],
 
     "lilconfig": ["lilconfig@3.1.3", "", {}, "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="],
 

--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
 		"@stauro/filebase-upload": "npm:@jsr/stauro__filebase-upload",
 		"@types/bun": "^1.3.10",
 		"@types/varint": "^6.0.3",
+		"abort-error": "^1.0.2",
 		"hamt-sharding": "^3.0.8",
 		"interface-blockstore": "^7.0.1",
 		"interface-store": "^8.0.0",
 		"ipfs-unixfs": "^13.0.0",
-		"it-all": "^3.0.11",
 		"multiformats": "^14.0.0",
 		"nanotar": "^0.3.0",
 		"ox": "^0.14.8",
@@ -39,7 +39,7 @@
 	"description": "🌸 Self-custodial decentralized deployments",
 	"engineStrict": true,
 	"engines": {
-		"node": "^20.10.0 || >=21.1.0"
+		"node": ">=22"
 	},
 	"files": [
 		"dist"

--- a/src/utils/ipfs.ts
+++ b/src/utils/ipfs.ts
@@ -46,23 +46,15 @@ export const packCAR = async (
 
   // `out` must be drained while blocks are being fed in: `CarWriter` hands
   // chunks over one at a time and `writer.put` will not resolve until the
-  // previous chunk has been taken.
-  const carChunks: Uint8Array[] = []
-  const collecting = (async () => {
-    for await (const chunk of out) {
-      carChunks.push(chunk)
-    }
-  })()
+  // previous chunk has been taken. Start collecting now, await it after the
+  // writer is closed.
+  const collecting = Array.fromAsync(out)
 
   for await (const { cid, bytes } of blockstore.getAll()) {
     try {
-      const chunks: Uint8Array[] = []
-      for await (const chunk of bytes) {
-        chunks.push(chunk)
-      }
       await writer.put({
         cid,
-        bytes: concatBytes(chunks),
+        bytes: concatBytes(await Array.fromAsync(bytes)),
       })
     } catch (error) {
       console.warn(`Failed to add block ${cid.toString()} to CAR:`, error)
@@ -70,7 +62,7 @@ export const packCAR = async (
   }
 
   await writer.close()
-  await collecting
+  const carChunks = await collecting
 
   // Release the blocks before joining the CAR chunks so peak memory stays at
   // roughly one copy of the blocks plus one copy of the CAR, as it was when

--- a/src/utils/ipfs.ts
+++ b/src/utils/ipfs.ts
@@ -44,10 +44,8 @@ export const packCAR = async (
 
   const { writer, out } = CarWriter.create([rootCID])
 
-  // `out` must be drained while blocks are being fed in: `CarWriter` hands
-  // chunks over one at a time and `writer.put` will not resolve until the
-  // previous chunk has been taken. Start collecting now, await it after the
-  // writer is closed.
+  // Must be drained while blocks are fed in: `writer.put` will not resolve
+  // until the previous chunk has been taken off `out`.
   const collecting = Array.fromAsync(out)
 
   for await (const { cid, bytes } of blockstore.getAll()) {
@@ -64,9 +62,8 @@ export const packCAR = async (
   await writer.close()
   const carChunks = await collecting
 
-  // Release the blocks before joining the CAR chunks so peak memory stays at
-  // roughly one copy of the blocks plus one copy of the CAR, as it was when
-  // this read the finished file back off disk.
+  // Released before joining the chunks so peak memory stays at roughly one
+  // copy of the blocks plus one of the CAR.
   blockstore.clear()
 
   const bytes = concatBytes(carChunks)

--- a/src/utils/ipfs/blockstore.ts
+++ b/src/utils/ipfs/blockstore.ts
@@ -5,8 +5,7 @@ import { base32 } from 'multiformats/bases/base32'
 import type { CID } from 'multiformats/cid'
 
 // interface-store v8 dropped these helpers and moved `AbortOptions` to
-// `abort-error`. They only ever described "sync or async", so keep them local
-// rather than depending on a package that no longer exports them.
+// `abort-error`. They only ever meant "sync or async", so keep them local.
 type Await<T> = T | Promise<T>
 type AwaitIterable<T> = Iterable<T> | AsyncIterable<T>
 type AwaitGenerator<T> = Generator<T> | AsyncGenerator<T>
@@ -66,9 +65,8 @@ export class MemoryBlockstore implements Blockstore {
       return this._put(key, [val], options)
     }
 
-    // Only an async source forces this to return a promise. Spreading a sync
-    // iterable stays on the synchronous path, which `Await<CID>` allows and
-    // which `Array.fromAsync` could not do -- it always returns a promise.
+    // Only an async source forces a promise here. `Array.fromAsync` always
+    // returns one, so sync iterables take the spread to stay synchronous.
     if (Symbol.asyncIterator in val) {
       return Array.fromAsync(val).then((bytes) =>
         this._put(key, bytes, options),

--- a/src/utils/ipfs/blockstore.ts
+++ b/src/utils/ipfs/blockstore.ts
@@ -1,18 +1,15 @@
+import type { AbortOptions } from 'abort-error'
 import type { Blockstore, InputPair, Pair } from 'interface-blockstore'
-import type {
-  AbortOptions,
-  Await,
-  AwaitGenerator,
-  AwaitIterable,
-} from 'interface-store'
 import { NotFoundError } from 'interface-store'
-import all from 'it-all'
 import { base32 } from 'multiformats/bases/base32'
 import type { CID } from 'multiformats/cid'
 
-function isPromise<T>(p?: any): p is Promise<T> {
-  return typeof p?.then === 'function'
-}
+// interface-store v8 dropped these helpers and moved `AbortOptions` to
+// `abort-error`. They only ever described "sync or async", so keep them local
+// rather than depending on a package that no longer exports them.
+type Await<T> = T | Promise<T>
+type AwaitIterable<T> = Iterable<T> | AsyncIterable<T>
+type AwaitGenerator<T> = Generator<T> | AsyncGenerator<T>
 
 type Entry = {
   cid: CID
@@ -65,23 +62,20 @@ export class MemoryBlockstore implements Blockstore {
   ): Await<CID> {
     options?.signal?.throwIfAborted()
 
-    let buf: Uint8Array[]
-
     if (val instanceof Uint8Array) {
-      buf = [val]
-    } else {
-      const result = all(val)
-
-      if (isPromise<Uint8Array[]>(result)) {
-        return result.then((val) => {
-          return this._put(key, val, options)
-        })
-      } else {
-        buf = result
-      }
+      return this._put(key, [val], options)
     }
 
-    return this._put(key, buf, options)
+    // Only an async source forces this to return a promise. Spreading a sync
+    // iterable stays on the synchronous path, which `Await<CID>` allows and
+    // which `Array.fromAsync` could not do -- it always returns a promise.
+    if (Symbol.asyncIterator in val) {
+      return Array.fromAsync(val).then((bytes) =>
+        this._put(key, bytes, options),
+      )
+    }
+
+    return this._put(key, [...val], options)
   }
 
   private _put(

--- a/src/utils/ipfs/unixfs.ts
+++ b/src/utils/ipfs/unixfs.ts
@@ -100,8 +100,6 @@ export class InvalidContentError extends Error {
   }
 }
 
-// --- async iteration helpers (inlined from it-batch / it-parallel-batch) ---
-
 /**
  * Collect `source` into arrays of at most `size`. Accepts sync or async
  * sources — the balanced layout recurses with a plain array.
@@ -156,8 +154,6 @@ async function* parallelBatch<T>(
   }
 }
 
-// --- block persistence ---
-
 interface PersistOptions {
   codec?: BlockCodec<number, unknown>
   cidVersion?: CIDVersion
@@ -181,8 +177,6 @@ const persist = async (
 
   return cid
 }
-
-// --- chunking ---
 
 /**
  * Fixed-size chunker. Emits exactly `CHUNK_SIZE` bytes per chunk apart from a
@@ -208,7 +202,6 @@ async function* fixedSizeChunker(
     while (currentLength >= CHUNK_SIZE) {
       const head = queue[0]
 
-      // Fast path: the whole chunk is already contiguous in the head buffer.
       if (head.byteLength - offset >= CHUNK_SIZE) {
         yield head.subarray(offset, offset + CHUNK_SIZE)
         offset += CHUNK_SIZE
@@ -273,8 +266,6 @@ async function* fixedSizeChunker(
   }
 }
 
-// --- content normalisation ---
-
 function isIterable(thing: unknown): thing is Iterable<Uint8Array> {
   return Symbol.iterator in (thing as object)
 }
@@ -335,8 +326,6 @@ async function* validateChunks(
   }
 }
 
-// --- leaf blocks ---
-
 /**
  * Write each chunk as a raw block. Under `rawLeaves` the leaf carries no
  * UnixFS wrapper, so leaves are always CIDv1 + raw codec regardless of the
@@ -394,8 +383,6 @@ async function* buildFileBatch(
     yield previous
   }
 }
-
-// --- file DAG assembly ---
 
 type Reducer = (
   leaves: InProgressImportResult[],
@@ -487,10 +474,6 @@ const reduce = (file: File, blockstore: WritableStorage): Reducer => {
   }
 }
 
-/**
- * Balanced layout: fold leaves into parents `MAX_CHILDREN_PER_NODE` at a time,
- * then fold the parents, until a single root remains.
- */
 async function balancedLayout(
   source:
     | AsyncIterable<InProgressImportResult>
@@ -516,8 +499,6 @@ const buildFile = async (
 ): Promise<InProgressImportResult> =>
   balancedLayout(buildFileBatch(file, blockstore), reduce(file, blockstore))
 
-// --- directory nodes ---
-
 const buildDir = async (
   dir: { path?: string; mtime?: Mtime; mode?: number; originalPath?: string },
   blockstore: WritableStorage,
@@ -539,8 +520,6 @@ const buildDir = async (
     block,
   }
 }
-
-// --- candidate stream -> DAG stream ---
 
 function isFileCandidate(entry: ImportCandidate): entry is FileCandidate {
   return (entry as FileCandidate).content != null
@@ -587,8 +566,6 @@ async function* dagBuilder(
     }
   }
 }
-
-// --- directory tree ---
 
 interface DirProps {
   root: boolean
@@ -642,7 +619,6 @@ abstract class Dir {
   abstract childCount(): number
 }
 
-/** UTF-8 byte length of `str` without allocating an encoded copy. */
 function utf8ByteLength(str: string): number {
   let len = 0
 
@@ -778,8 +754,6 @@ class DirFlat extends Dir {
   }
 }
 
-// --- HAMT-sharded directories ---
-
 /**
  * go-ipfs truncates murmur3-128 to its first 64 bits and stores them
  * little-endian; both quirks are load-bearing for CID parity.
@@ -855,7 +829,6 @@ function isDir(obj: unknown): obj is Dir {
   return typeof (obj as Dir)?.flush === 'function'
 }
 
-/** Build the UnixFS node describing one HAMT bucket. */
 function shardNode(
   bucket: Bucket<InProgressImportResult | Dir>,
   shardRoot: DirSharded | null,

--- a/src/utils/tar.ts
+++ b/src/utils/tar.ts
@@ -13,13 +13,10 @@ export const packTAR = async (
   const entries: TarFileItem[] = []
 
   for (const { path, content } of files) {
-    const chunks: Uint8Array[] = []
-    let totalLength = 0
+    const chunks = await Array.fromAsync(content)
 
-    for await (const chunk of content) {
-      chunks.push(chunk)
-      totalLength += chunk.length
-    }
+    let totalLength = 0
+    for (const c of chunks) totalLength += c.length
 
     const fileData = new Uint8Array(totalLength)
     let offset = 0

--- a/test/utils/ipfs/blockstore.test.ts
+++ b/test/utils/ipfs/blockstore.test.ts
@@ -1,7 +1,6 @@
 import { describe, it } from 'bun:test'
 import * as assert from 'node:assert'
 import { NotFoundError } from 'interface-store'
-import all from 'it-all'
 import { CID } from 'multiformats/cid'
 import * as raw from 'multiformats/codecs/raw'
 import { sha256 } from 'multiformats/hashes/sha2'
@@ -120,7 +119,7 @@ describe('MemoryBlockstore', () => {
         yield { cid: cid2, bytes: new TextEncoder().encode('b') }
       })()
 
-      const results = await all(bs.putMany(source))
+      const results = await Array.fromAsync(bs.putMany(source))
       assert.deepStrictEqual(results, [cid1, cid2])
       assert.strictEqual(await bs.has(cid1), true)
       assert.strictEqual(await bs.has(cid2), true)
@@ -135,7 +134,7 @@ describe('MemoryBlockstore', () => {
       await bs.put(cid1, new TextEncoder().encode('x'))
       await bs.put(cid2, new TextEncoder().encode('y'))
 
-      const pairs = await all(
+      const pairs = await Array.fromAsync(
         bs.getMany(
           (async function* () {
             yield cid1
@@ -158,7 +157,7 @@ describe('MemoryBlockstore', () => {
       await bs.put(cid1, new TextEncoder().encode('del1'))
       await bs.put(cid2, new TextEncoder().encode('del2'))
 
-      const results = await all(
+      const results = await Array.fromAsync(
         bs.deleteMany(
           (async function* () {
             yield cid1

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "module": "NodeNext",
     "target": "es2023",
+    "lib": ["ES2023", "ESNext.Array", "DOM"],
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
> ⚠️ **Contains a `BREAKING CHANGE:` footer**, so semantic-release will cut a **major** (3.1.2 → 4.0.0). Dropping a Node major is genuinely breaking with `engineStrict: true`, so shipping it as a patch felt wrong — but if you'd rather batch it with other breaking work, say so and I'll reword the footer.

Follow-up to the ES2025/ES2026 survey. The headline: **there is no perf win here.** This is a correctness and readability change that happens to be unlocked by a runtime bump.

## Raise the Node floor to 22

`engines` said `^20.10.0 || >=21.1.0`. [Node 20 reached EOL on 2026-04-30](https://endoflife.ai/article-nodejs-eol) and gets no further security patches, and CI has only ever tested 22 and 24 (`pkg-pr-new.yml` pins 22, `release.yml` pins 24). With `engineStrict: true` that range was promising installs on a runtime nothing here exercises.

22 is also the floor for the [V8 12.4 features](https://nodejs.org/en/blog/announcements/v22-release-announce) this unlocks.

**On `lib`:** `Array.fromAsync` is declared only in `lib.esnext.array.d.ts`, which the default `es2023` lib doesn't include. It's set to `["ES2023", "ESNext.Array", "DOM"]` rather than plain `ESNext` deliberately — the narrow list keeps `using` and `Uint8Array.prototype.toBase64` out of reach, since **those need Node 24** and would otherwise type-check green against a runtime we don't require. `DOM` is restored explicitly because naming `lib` at all drops the `es2023.full` default that supplies `fetch`, `Blob` and `File`.

## Repair the blockstore types

`MemoryBlockstore` was written against `interface-store` **v7**. v8 removed `Await`, `AwaitIterable` and `AwaitGenerator` outright and moved `AbortOptions` to `abort-error` — so all four imports have been unresolved. Those helpers only ever meant "sync or async", so they're now local aliases.

`put` also used `it-all`, whose return type resolves to `unknown[]` here. Between them that's **all 5 pre-existing `src/` type errors**:

```
bun run types:  44 errors → 39     (0 remaining in src/)
```

## Array.fromAsync

`put` branched on whether `it-all`'s result was a promise, to keep a synchronous path for sync sources. `Array.fromAsync` **cannot** express that — it always returns a promise — so the branch is now an explicit `Symbol.asyncIterator in val` check: async sources use `Array.fromAsync`, sync ones use a spread. That's not just tidier; iterating a sync source with `for await` costs a microtask per item (measured 22.7 ms vs 3.6 ms for `Array.from` over 200k items on bun). This drops the `it-all` dependency.

In `packCAR` and `packTAR`, `Array.fromAsync` replaces hand-rolled collect loops. Readability only — over 200k chunks it's ~36% *slower* than a manual loop on bun and ~10% faster on Node.

## Deliberately not included

- **`using` / `Symbol.dispose`** on `MemoryBlockstore` — the `using` *syntax* needs Node 24; 22 exposes the symbols but won't parse the keyword. Also worth noting the blockstore is a local, so GC reclaims it regardless; `clear()` only drops references sooner. Not a leak fix.
- **Iterator helpers** — sync-only, and essentially all iteration here is async. The AsyncIterator helpers proposal is still pre-Stage-4.
- **`Uint8Array.prototype.toBase64` / `toHex`** — the best fit for this codebase's multibase work, but not shipped even in Node 24.4 yet.
- **`Set` methods, `Object.groupBy`, `RegExp.escape`, `Promise.try`** — no applicable sites. `Error.isError` has exactly one (`squid.ts:292`) and matters mainly across realms; marginal for a single-realm CLI.

## Verification

- **CAR bytes, root CID and TAR bytes byte-identical** before and after
- Typecheck 44 → 39, none introduced
- Full suite: 174 pass / 8 skip / **5 fail — the same 5 live-network AIOZ and IPFSNinja tests that fail on a clean `main`**
- Bundle 809.0 kB, under the 1 MB limit; lint clean

Runtime support beyond Node, per your note: verified locally on **bun 1.4.0**. I did not verify bun 1.3 or any Deno 2 build — worth a sanity check if you want those stated as supported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)